### PR TITLE
Fix Dockerfile to use uv instead of pip for dependency management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,14 +25,15 @@ WORKDIR /home/docker/app
 EXPOSE 8080
 
 # Copiez les fichiers de configuration et d'installation du projet dans le répertoire de travail
-COPY requirements.in .
+COPY pyproject.toml uv.lock ./
 
-# Installez les dépendances Python nécessaires
+# Installez les dépendances Python nécessaires avec uv
 RUN pip install --upgrade pip
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir uv
+RUN uv sync --frozen --no-dev
 
 # Copiez le reste des fichiers du projet dans le répertoire de travail
 COPY . .
 
 # Définissez la commande pour exécuter votre application
-CMD streamlit run app.py --server.port 8080
+CMD uv run streamlit run app.py --server.port 8080


### PR DESCRIPTION
- Replace non-existent requirements.in with pyproject.toml and uv.lock
- Install and use uv for dependency management (consistent with project tooling)
- Use uv sync --frozen --no-dev for reproducible builds
- Run application with uv run to ensure correct environment

This aligns the Docker workflow with the local development workflow and ensures faster, more reliable builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)